### PR TITLE
Fix ESP:wifiConnect CWMODE exec

### DIFF
--- a/espduino.cpp
+++ b/espduino.cpp
@@ -61,7 +61,7 @@ BOOL ESP::wifiConnect(const char* ssid, const char* pass)
   CHECK(!reset(), "RESET ESP failed");
   INFO("RESET ESP done");
   CHECK(!exec("ATE0", "OK", 1000), "ATE0 failed");
-  CHECK(!exec("AT+CWMODE=1", "OK", 1000), "CWMODE failed");
+  CHECK(exec("AT+CWMODE=1", "ERROR", 1000), "CWMODE failed");
   delay(200);
   CHECK(!exec(temp, "OK", 30000), "CWJAP failed");
   wifiCb(0);


### PR DESCRIPTION
If AT+CWMODE is already 1, it returns "no changes (or similar)" instead of "OK" .